### PR TITLE
Move cursor after embed when inserting

### DIFF
--- a/draft-js-embed-plugin/src/modifiers/addEmbed.js
+++ b/draft-js-embed-plugin/src/modifiers/addEmbed.js
@@ -14,6 +14,6 @@ export default (editorState, url) => {
   )
   return EditorState.forceSelection(
     newEditorState,
-    editorState.getCurrentContent().getSelectionAfter()
+    newEditorState.getCurrentContent().getSelectionAfter()
   )
 }


### PR DESCRIPTION
Right now, when you insert an embed the cursor is afterwards _above_ the embed, rather than below it. With this fix the cursor is correctly moved after the embed, which makes for a much nicer writing experience.

Reference `image-plugin` PR with the same fix: https://github.com/draft-js-plugins/draft-js-plugins/pull/928