### PR TITLE
Fix DraftEntity.get deprecation warning

### DIFF
--- a/draft-js-embed-plugin/src/embed/index.js
+++ b/draft-js-embed-plugin/src/embed/index.js
@@ -1,4 +1,3 @@
-import { Entity } from 'draft-js'
 import React, { Component } from 'react'
 
 export default class Embed extends Component {
@@ -18,9 +17,11 @@ export default class Embed extends Component {
       offsetKey, // eslint-disable-line no-unused-vars
       selection, // eslint-disable-line no-unused-vars
       tree, // eslint-disable-line no-unused-vars
+      contentState,
       ...elementProps
     } = otherProps
-    const { src } = Entity.get(block.getEntityAt(0)).getData()
+    const entity = block.getEntityAt(0);
+    const { src } = contentState.getEntity(entity).getData();
     return (
       <div className={theme.embedStyles.embedWrapper}>
         <iframe

--- a/draft-js-embed-plugin/src/index.js
+++ b/draft-js-embed-plugin/src/index.js
@@ -6,7 +6,6 @@
  * License: MIT
  */
 
-import { Entity } from 'draft-js'
 import decorateComponentWithProps from 'decorate-component-with-props'
 import addEmbed from './modifiers/addEmbed'
 import EmbedComponent from './embed'
@@ -22,10 +21,14 @@ export default (config = {}) => {
   }
   const ThemedEmbed = decorateComponentWithProps(Embed, { theme })
   return {
-    blockRendererFn: (block) => {
+    blockRendererFn: (block, { getEditorState }) => {
       if (block.getType() === 'atomic') {
-        const entity = Entity.get(block.getEntityAt(0))
-        const type = entity.getType()
+        const contentState = getEditorState().getCurrentContent()
+        const entity = block.getEntityAt(0)
+        if (entity) {
+          return null
+        }
+        const type = contentState.getEntity(entity).getType()
         if (type === 'embed') {
           return {
             component: ThemedEmbed,

--- a/draft-js-link-plugin/src/linkStrategy.js
+++ b/draft-js-link-plugin/src/linkStrategy.js
@@ -1,12 +1,11 @@
-import { Entity } from 'draft-js'
 
-function linkStrategy (contentBlock, cb) {
+function linkStrategy (contentBlock, cb, contentState) {
   contentBlock.findEntityRanges(
     (character) => {
       const entityKey = character.getEntity()
       return (
         entityKey !== null &&
-        Entity.get(entityKey).getType() === 'LINK'
+        contentState.getEntity(entityKey).getType() === 'LINK'
       )
     },
     cb


### PR DESCRIPTION
This should remove deprecation warnings caused by Draft.js and fix a bug on Spectrum.
I couldn't test it, so please someone do it, but it should work.